### PR TITLE
manifest: add File: attribute

### DIFF
--- a/manifest/example_test.go
+++ b/manifest/example_test.go
@@ -2,13 +2,13 @@ package manifest_test
 
 import (
 	"bufio"
-	"fmt"
 	"strings"
+	"testing"
 
 	"github.com/docker-library/go-dockerlibrary/manifest"
 )
 
-func Example() {
+func TestExample(t *testing.T) {
 	man, err := manifest.Parse(bufio.NewReader(strings.NewReader(`# RFC 2822
 
 	# I LOVE CAKE
@@ -60,20 +60,30 @@ Tags: raspbian-s390x
 Architectures: s390x, i386
 
 
+Tags: 1.5-withfile
+SharedTags: 1.5-debian
+GitCommit: d7e2a8d90a9b8f5dfd5bcd428e0c33b68c40cc19
+File: Dockerfile-15
+
+Tags: 1.5-withdirandfile
+SharedTags: 1.5-debian
+GitCommit: d7e2a8d90a9b8f5dfd5bcd428e0c33b68c40cc19
+Directory: 1.5
+File: Dockerfile-debian
 `)))
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
-	fmt.Printf("-------------\n2822:\n%s\n", man)
+	t.Logf("-------------\n2822:\n%s\n", man)
 
-	fmt.Printf("\nShared Tag Groups:\n")
+	t.Logf("\nShared Tag Groups:\n")
 	for _, group := range man.GetSharedTagGroups() {
-		fmt.Printf("\n  - %s\n", strings.Join(group.SharedTags, ", "))
+		t.Logf("\n  - %s\n", strings.Join(group.SharedTags, ", "))
 		for _, entry := range group.Entries {
-			fmt.Printf("    - %s\n", entry.TagsString())
+			t.Logf("    - %s\n", entry.TagsString())
 		}
 	}
-	fmt.Printf("\n")
+	t.Logf("\n")
 
 	man, err = manifest.Parse(bufio.NewReader(strings.NewReader(`
 # maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
@@ -90,7 +100,7 @@ i: g@h j
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("-------------\nline-based:\n%v\n", man)
+	t.Logf("-------------\nline-based:\n%v\n", man)
 
 	// Output:
 	// -------------
@@ -151,15 +161,15 @@ i: g@h j
 	// Directory: j
 }
 
-func ExampleFetch_local() {
+func TestExampleFetch_local(t *testing.T) {
 	repoName, tagName, man, err := manifest.Fetch("testdata", "bash:4.4")
 	if err != nil {
 		panic(err)
 	}
 
-	fmt.Printf("%s:%s\n\n", repoName, tagName)
+	t.Logf("%s:%s\n\n", repoName, tagName)
 
-	fmt.Println(man.GetTag(tagName).ClearDefaults(manifest.DefaultManifestEntry).String())
+	t.Log(man.GetTag(tagName).ClearDefaults(manifest.DefaultManifestEntry).String())
 
 	// Output:
 	// bash:4.4
@@ -171,15 +181,15 @@ func ExampleFetch_local() {
 	// Directory: 4.4
 }
 
-func ExampleFetch_remote() {
+func TestExampleFetch_remote(t *testing.T) {
 	repoName, tagName, man, err := manifest.Fetch("/home/jsmith/docker/official-images/library", "https://github.com/docker-library/official-images/raw/1a3c4cd6d5cd53bd538a6f56a69f94c5b35325a7/library/bash:4.4")
 	if err != nil {
 		panic(err)
 	}
 
-	fmt.Printf("%s:%s\n\n", repoName, tagName)
+	t.Logf("%s:%s\n\n", repoName, tagName)
 
-	fmt.Println(man.GetTag(tagName).ClearDefaults(manifest.DefaultManifestEntry).String())
+	t.Log(man.GetTag(tagName).ClearDefaults(manifest.DefaultManifestEntry).String())
 
 	// Output:
 	// bash:4.4

--- a/manifest/rfc2822.go
+++ b/manifest/rfc2822.go
@@ -38,6 +38,7 @@ type Manifest2822Entry struct {
 	GitFetch  string
 	GitCommit string
 	Directory string
+	File      string
 
 	// architecture-specific versions of the above fields
 	ArchValues map[string]string
@@ -56,6 +57,7 @@ var (
 
 		GitFetch:  "refs/heads/master",
 		Directory: ".",
+		File:      "Dockerfile",
 	}
 )
 
@@ -81,7 +83,7 @@ func (entry Manifest2822Entry) Clone() Manifest2822Entry {
 
 func (entry *Manifest2822Entry) SeedArchValues() {
 	for field, val := range entry.Paragraph.Values {
-		if strings.HasSuffix(field, "-GitRepo") || strings.HasSuffix(field, "-GitFetch") || strings.HasSuffix(field, "-GitCommit") || strings.HasSuffix(field, "-Directory") {
+		if strings.HasSuffix(field, "-GitRepo") || strings.HasSuffix(field, "-GitFetch") || strings.HasSuffix(field, "-GitCommit") || strings.HasSuffix(field, "-Directory") || strings.HasSuffix(field, "-File") {
 			entry.ArchValues[field] = val
 		}
 	}
@@ -118,7 +120,7 @@ func (a Manifest2822Entry) SameBuildArtifacts(b Manifest2822Entry) bool {
 		}
 	}
 
-	return a.ArchitecturesString() == b.ArchitecturesString() && a.GitRepo == b.GitRepo && a.GitFetch == b.GitFetch && a.GitCommit == b.GitCommit && a.Directory == b.Directory && a.ConstraintsString() == b.ConstraintsString()
+	return a.ArchitecturesString() == b.ArchitecturesString() && a.GitRepo == b.GitRepo && a.GitFetch == b.GitFetch && a.GitCommit == b.GitCommit && a.Directory == b.Directory && a.File == b.File && a.ConstraintsString() == b.ConstraintsString()
 }
 
 // returns a list of architecture-specific fields in an Entry
@@ -160,6 +162,9 @@ func (entry Manifest2822Entry) ClearDefaults(defaults Manifest2822Entry) Manifes
 	if entry.Directory == defaults.Directory {
 		entry.Directory = ""
 	}
+	if entry.File == defaults.File {
+		entry.File = ""
+	}
 	for _, key := range defaults.archFields() {
 		if defaults.ArchValues[key] == entry.ArchValues[key] {
 			delete(entry.ArchValues, key)
@@ -196,6 +201,9 @@ func (entry Manifest2822Entry) String() string {
 	}
 	if str := entry.Directory; str != "" {
 		ret = append(ret, "Directory: "+str)
+	}
+	if str := entry.File; str != "" {
+		ret = append(ret, "File: "+str)
 	}
 	for _, key := range entry.archFields() {
 		ret = append(ret, key+": "+entry.ArchValues[key])
@@ -261,6 +269,13 @@ func (entry Manifest2822Entry) ArchDirectory(arch string) string {
 		return val
 	}
 	return entry.Directory
+}
+
+func (entry Manifest2822Entry) ArchFile(arch string) string {
+	if val, ok := entry.ArchValues[arch+"-File"]; ok && val != "" {
+		return val
+	}
+	return entry.File
 }
 
 func (entry Manifest2822Entry) HasTag(tag string) bool {


### PR DESCRIPTION
It is useful to have multiple dockerfiles in a single directory, if for
example multiple apps need to have access to the root of the repo to be
built.